### PR TITLE
Set TeX typesetting parameters to make sure all paragraphs are well typesetted

### DIFF
--- a/graduation-thesis/main.tex
+++ b/graduation-thesis/main.tex
@@ -176,6 +176,12 @@
 \renewcommand{\thetable}{\thechapter-\arabic{table}}
 \captionsetup[table]{font=small,labelsep=space,skip=2pt}
 
+% 调整底层 TeX 排版引擎参数以保证所有段落能够很好地以两端对齐的方式呈现
+\tolerance=1
+\emergencystretch=\maxdimen
+\hyphenpenalty=10000
+\hbadness=10000
+
 % 设置数学公式编号格式
 \renewcommand{\theequation}{\arabic{chapter}-\arabic{equation}}
 


### PR DESCRIPTION
Before this PR, sometimes paragraphs may be typesetted as follows which is not acceptable:

![图片](https://user-images.githubusercontent.com/29401356/83372624-68947c80-a3f8-11ea-849d-e232bebf4893.png)

This PR addresses this issue and fixes it.

> Note: due to the change of the parameters to the underlying TeX typesetting engine, this commits should be well tested before merging.